### PR TITLE
Fix expression parsing returning same value on both sides

### DIFF
--- a/src/SimilarityFunction.php
+++ b/src/SimilarityFunction.php
@@ -51,7 +51,7 @@ final class SimilarityFunction extends FunctionNode
             return $expression;
         }
 
-        return $this->fieldExpression->dispatch(
+        return $expression->dispatch(
             $sqlWalker,
         );
     }


### PR DESCRIPTION
Hi,

This PR fixes the generated SQL for expression `SIMILARITY(field, :val)`, as it currently outputs `SIMILARITY(field, field)`.